### PR TITLE
Create Délégation à la Protection des Données.md

### DIFF
--- a/projet/rôles/Délégation à la Protection des Données Plateforme.md
+++ b/projet/rôles/Délégation à la Protection des Données Plateforme.md
@@ -1,4 +1,4 @@
-# Rôle délégué à la protection des données (DPO in English), conformité RGPD
+# Rôle délégué à la protection des données Plateforme (DPO in English), conformité RGPD
 
 **Besoins / raison d'être** :
 
@@ -7,18 +7,17 @@
 **Redevabilités / engagements** :
 
  - informer et conseiller les personnes chargées de récolter et traiter les données personnelles, au sein des CdlT mais aussi sensibilisation auprès des Lieux accueillants, et d'éventuels sous-traitants
- - être la personne référente et relectrice pour tout document, matérialisé ou pas, ayant vocation à récolter des données personnelles
+ - être la personne référente et relectrice pour tout élément publié sur le site vitrine ou la plateforme, ayant vocation à récolter des données personnelles
  - être la personne contactée par les usagers concernant l'excercice de leurs droits d'accès, de modification, de rectification, de portabilité, de limitation, d’opposition et d’effacement des données
  - et réagir à leur demande dans un délai inférieur à 24 heures
  - en cas d’indisponibilité, s’assurer de transmettre les informations à une autre personne et mettre à jour son nom dans le [fichier de structuration](https://docs.google.com/document/d/1bw2Ms8SPsBeiTI0qhlFbx4cpz7-ec3n4uag8w02Qzg0/edit#)
  - constituer et regrouper la documentation nécessaire pour prouver la conformité au règlement
- - contrôler plus généralement le respect du règlement et du droit national en matière de protection des données (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))
- - conseiller l’organisme sur la réalisation d’études d'impact sur la protection des données et d’en vérifier l’exécution (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))
+ - *contrôler plus généralement le respect du règlement et du droit national en matière de protection des données (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))*
+ - *conseiller l’organisme sur la réalisation d’études d'impact sur la protection des données et d’en vérifier l’exécution (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))*
  - coopérer avec l’autorité de contrôle et d’être le point de contact de celle-ci (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))
 
 **Idées de moyens d'actions** :
 
-- participer à la mise en place un système d'information sécurisé, auto-hébergé, à la fois respectueux et fonctionnel, décorrélé des GAFAMa...z
 - participer à la mise en place d'un système d'alerte en cas de contact pour exercice du droit d'accès, de modification, de rectification, de portabilité, de limitation, d’opposition et d’effacement des données, pour permettre une réaction rapide et facile
 - remonter les failles constatées par la création d'issues GitHub dédiées
 - participer à la mise en place d'une cartographie de l'information : quelle info est stockée où ?
@@ -27,9 +26,6 @@
 
  - [site vitrine des Chemins de la Transition](https://lescheminsdelatransition.org/)
  - [plateforme V0.1 en YesWiki](https://lescheminsdelatransition.org/plateforme/)
- - plateforme V1 puis V2 en SemApps ; page dédiée sur le site vitrine : https://lescheminsdelatransition.org/les-technologies-utilisees-2/
- - tout document à visée externe ou interne récoltant des données personnelles
- - et plus largement tout le système d'information et outils de travail et de communication des CdlT : espace de stockage en ligne, chat, visio
  
 **Ressources** :
 

--- a/projet/rôles/Délégation à la Protection des Données.md
+++ b/projet/rôles/Délégation à la Protection des Données.md
@@ -1,0 +1,42 @@
+# Rôle délégué à la protection des données (DPO in English), conformité RGPD
+
+**Besoins / raison d'être** :
+
+ - assurer le respect de la protection des données personnelles dans la conformité du RGPD : [site CNIL — Se préparer en 6 étapes](https://www.cnil.fr/fr/principes-cles/rgpd-se-preparer-en-6-etapes)
+
+**Redevabilités / engagements** :
+
+ - informer et conseiller les personnes chargées de récolter et traiter les données personnelles, au sein des CdlT mais aussi sensibilisation auprès des Lieux accueillants, et d'éventuels sous-traitants
+ - être la personne référente et relectrice pour tout document, matérialisé ou pas, ayant vocation à récolter des données personnelles
+ - être la personne contactée par les usagers concernant l'excercice de leurs droits d'accès, de modification, de rectification, de portabilité, de limitation, d’opposition et d’effacement des données
+ - et réagir à leur demande dans un délai inférieur à 24 heures
+ - en cas d’indisponibilité, s’assurer de transmettre les informations à une autre personne et mettre à jour son nom dans le [fichier de structuration](https://docs.google.com/document/d/1bw2Ms8SPsBeiTI0qhlFbx4cpz7-ec3n4uag8w02Qzg0/edit#)
+ - constituer et regrouper la documentation nécessaire pour prouver la conformité au règlement
+ - contrôler plus généralement le respect du règlement et du droit national en matière de protection des données (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))
+ - conseiller l’organisme sur la réalisation d’études d'impact sur la protection des données et d’en vérifier l’exécution (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))
+ - coopérer avec l’autorité de contrôle et d’être le point de contact de celle-ci (sic [CNIL : désigner un pilote](https://www.cnil.fr/fr/designer-un-pilote))
+
+**Idées de moyens d'actions** :
+
+- participer à la mise en place un système d'information sécurisé, auto-hébergé, à la fois respectueux et fonctionnel, décorrélé des GAFAMa...z
+- participer à la mise en place d'un système d'alerte en cas de contact pour exercice du droit d'accès, de modification, de rectification, de portabilité, de limitation, d’opposition et d’effacement des données, pour permettre une réaction rapide et facile
+- remonter les failles constatées par la création d'issues GitHub dédiées
+- participer à la mise en place d'une cartographie de l'information : quelle info est stockée où ?
+
+**Périmètre / domaine d'action** :
+
+ - [site vitrine des Chemins de la Transition](https://lescheminsdelatransition.org/)
+ - [plateforme V0.1 en YesWiki](https://lescheminsdelatransition.org/plateforme/)
+ - plateforme V1 puis V2 en SemApps ; page dédiée sur le site vitrine : https://lescheminsdelatransition.org/les-technologies-utilisees-2/
+ - tout document à visée externe ou interne récoltant des données personnelles
+ - et plus largement tout le système d'information et outils de travail et de communication des CdlT : espace de stockage en ligne, chat, visio
+ 
+**Ressources** :
+
+ - [CNIL : le DPO](https://www.cnil.fr/fr/le-delegue-la-protection-des-donnees-dpo)
+ - [CNIL : formulaire de désignation d'un DPO](https://www.cnil.fr/fr/designation-dpo)
+
+**Référent actuel** :
+
+ - 
+_Le référent est la personne qui fait déjà cette action, soit parce qu’elle a été désignée, soit parce que les choses ont amené cette situation. Bien que fortement liée à la gestion de l'organisation informatique, la personne référente n'est pas forcément développeur en fonction, afin de lui éviter d'être juge et partie. La personne indiquée ici n’a pas forcément été élue. Il y aura prochainement une redéfinition potentielle de ces référents suite à la structuration de la vie de l'association._


### PR DESCRIPTION
Idéalement, le DPO n'a pas de fonction directement en lien avec des traitements de données, afin de lui éviter d'être juge et partie, sauf à mettre en place un système de double contrôle ?
A-t-on les moyens humains et/ou financiers de faire intervenir une personne dégagée de tout risque de conflit d'intérêt, suffisamment formée et à la fois suffisamment familière avec l'organisation des CdlT ?
Les missions proposées dans cette définition de rôle contiennent, au-delà des strictes missions légales du DPO présentées par la CNIL, des missions d'amélioration qui peuvent être attribuées à une autre personne ou groupe de personnes non-DPO (si de telles disponibilités existent), auquel cas la création de deux rôles bien définis et distincts sera peut-être nécessaire.